### PR TITLE
[WORK IN PROGRESS] Attempting to link Unicode Data Tables for full String support

### DIFF
--- a/Plugins/PDCPlugin/PDCPlugin.swift
+++ b/Plugins/PDCPlugin/PDCPlugin.swift
@@ -50,6 +50,12 @@ struct ModuleBuildRequest {
         let swiftToolchain = try swiftToolchain()
         print("found Swift toolchain: \(swiftToolchain)")
 
+        let triple = "armv7em-none-none-eabi"
+        let toolchainPath = "\(home)Library/Developer/Toolchains/swift-latest.xctoolchain"
+        let unicodeDataTablesPathDevice = "\(toolchainPath)/usr/lib/swift/embedded/\(triple)"
+        let unicodeDataTablesPathSimulator = "\(toolchainPath)/usr/lib/swift/embedded/arm64-apple-none-macho"
+        let unicodeDataTablesLibName = "swiftUnicodeDataTables" // libswiftUnicodeDataTables.a
+
         let playdateSDK = try playdateSDK()
         print("found Playdate SDK")
 
@@ -251,6 +257,8 @@ struct ModuleBuildRequest {
                     print("building pdex.elf")
                     try cc([setup, module.modulePath(for: .device)] + mcFlags + [
                         "-T\(playdateSDK)/C_API/buildsupport/link_map.ld",
+                        // This does NOT seem to work for the device build:
+                        "-Wl,--verbose,-L\(unicodeDataTablesPathDevice),-l\(unicodeDataTablesLibName)",
                         "-Wl,-Map=\(context.pluginWorkDirectory.appending(["pdex.map"]).string),--cref,--gc-sections,--no-warn-mismatch,--emit-relocs",
                         "-o", sourcePath.appending(["pdex.elf"]).string
                     ])
@@ -280,6 +288,8 @@ struct ModuleBuildRequest {
                     try clang([
                         "-nostdlib", "-dead_strip",
                         "-Wl,-exported_symbol,_eventHandlerShim", "-Wl,-exported_symbol,_eventHandler",
+                        // While this seems to work fine for the simulator build:
+                        "-Wl,-L\(unicodeDataTablesPathSimulator),-l\(unicodeDataTablesLibName)",
                         module.modulePath(for: .simulator), "-dynamiclib", "-rdynamic", "-lm",
                         "-DTARGET_SIMULATOR=1", "-DTARGET_EXTENSION=1",
                         "-I", ".",


### PR DESCRIPTION
When attempting to use the full String API in Swift Embedded, compilation will fail (intentionally). The Unicode Data Tables need to be linked manually to acknowledge the cost (in binary size) of linking them.

This pull request attempts to add support for the linking commands to `PDCPlugin` (which is what handles building `PlaydateKit`-based projects).

#### Current state
- Simulator build: As far as I can tell, the linking _is_ working correctly.
- Device build: Despite the verbose messaging from `ld` showing that `libswiftUnicodeDataTables.a` is found, the link still fails with the below errors.

#### Reproduction
To test this (as it requires an actual 'game' too), I've created a simple game that utilizes the full String API (equality, in this case). That game is here (which can be cloned to see the issue): https://github.com/tyetrask/PlaydateKitTemplateTests/tree/unicode-data-tables-attempt (see [diff here](https://github.com/tyetrask/PlaydateKitTemplateTests/compare/main...unicode-data-tables-attempt)).

1. Clone project
2. Ensure you're on `unicode-data-tables-attempt` branch
3. Open in XCode
4. Ensure toolchain is set to latest nightly
5. Build and run
6. (See crash logs similar to below)

#### Example compilation logs
```
./arm-none-eabi/bin/ld: //<compiler-generated>:(.text.$ss7UnicodeO14_NFDNormalizerV13decomposeSlow33_B136021ACF5AAEFA178D70CE67C7EEF0LLyyAB6ScalarV6scalar_AB9_NormDataV04normO0t_tF+0x14e): undefined reference to `_swift_stdlib_getNormData'
/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: //<compiler-generated>:(.text.$ss7UnicodeO14_NFDNormalizerV13decomposeSlow33_B136021ACF5AAEFA178D70CE67C7EEF0LLyyAB6ScalarV6scalar_AB9_NormDataV04normO0t_tF+0x214): undefined reference to `_swift_stdlib_nfd_decompositions'
/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /Users/userhome/Projects/PlaydateKitTemplateTests/.build/plugins/PDCPlugin/outputs/playdatekittemplate_device.o: in function `$ss7UnicodeO14_NFCNormalizerV7_resume12consumingNFDAB6ScalarVSgAH6scalar_AB9_NormDataV04normI0tSgADzXE_tF04$ss7a4O14_b21V6resume9consumingAB6f25VSgAIyXE_tFAH6scalar_AB9_hI20V04normH0tSgADzXEfU_AIIgd_Tf1cn_nTf4ng_n':
//<compiler-generated>:(.text.$ss7UnicodeO14_NFCNormalizerV7_resume12consumingNFDAB6ScalarVSgAH6scalar_AB9_NormDataV04normI0tSgADzXE_tF04$ss7a4O14_b21V6resume9consumingAB6f25VSgAIyXE_tFAH6scalar_AB9_hI20V04normH0tSgADzXEfU_AIIgd_Tf1cn_nTf4ng_n+0x112): undefined reference to `_swift_stdlib_getComposition'
/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: //<compiler-generated>:(.text.$ss7UnicodeO14_NFCNormalizerV7_resume12consumingNFDAB6ScalarVSgAH6scalar_AB9_NormDataV04normI0tSgADzXE_tF04$ss7a4O14_b21V6resume9consumingAB6f25VSgAIyXE_tFAH6scalar_AB9_hI20V04normH0tSgADzXEfU_AIIgd_Tf1cn_nTf4ng_n+0x132): undefined reference to `_swift_stdlib_getComposition'
/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: /Users/userhome/Projects/PlaydateKitTemplateTests/.build/plugins/PDCPlugin/outputs/Source/pdex.elf: hidden symbol `_swift_stdlib_getDecompositionEntry' isn't defined
/usr/local/playdate/gcc-arm-none-eabi-9-2019-q4-major/bin/../lib/gcc/arm-none-eabi/9.2.1/../../../../arm-none-eabi/bin/ld: final link failed: bad value
collect2: error: ld returned 1 exit status

[2K
[31m[1merror: [0mccFailed(exitCode: 1)
```